### PR TITLE
Return result as to corresponding python value

### DIFF
--- a/PyChakra/__init__.py
+++ b/PyChakra/__init__.py
@@ -61,7 +61,7 @@ class Runtime:
             self.chakraCore.DllMain(0, 2, 0)
 
         # get JSON.stringify reference, and create its called arguments array
-        self.__jsonStringify = self.eval_js("JSON.stringify", raw=True)[1]
+        self.__jsonStringify = self.eval("JSON.stringify", raw=True)[1]
 
         undefined = ctypes.c_void_p()
         chakraCore.JsGetUndefinedValue(point(undefined))

--- a/PyChakra/__init__.py
+++ b/PyChakra/__init__.py
@@ -63,7 +63,7 @@ class Runtime:
         # get JSON.stringify reference, and create its called arguments array
         self.__jsonStringify = self.eval_js("JSON.stringify", raw=True)[1]
 
-        undefined = _ctypes.c_void_p()
+        undefined = ctypes.c_void_p()
         chakraCore.JsGetUndefinedValue(point(undefined))
 
         self.__jsonStringifyArgs = (ctypes.c_void_p * 2)()
@@ -74,10 +74,10 @@ class Runtime:
 
     if sys.platform == "win32":
         def eval(self, js_string, raw=False):
-            js_source = _ctypes.c_wchar_p("")
-            js_script = _ctypes.c_wchar_p(js_string)
+            js_source = ctypes.c_wchar_p("")
+            js_script = ctypes.c_wchar_p(js_string)
 
-            result = _ctypes.c_void_p()
+            result = ctypes.c_void_p()
             err = chakraCore.JsRunScript(js_script, 0, js_source, point(result))
 
             # eval success
@@ -114,7 +114,7 @@ class Runtime:
         self.__jsonStringifyArgs[1] = js_value
 
         # value => json
-        result = _ctypes.c_void_p()
+        result = ctypes.c_void_p()
         err = self.chakraCore.JsCallFunction(self.__jsonStringify, point(self.__jsonStringifyArgs), 2, point(result))
 
         if err == 0:
@@ -152,11 +152,11 @@ class Runtime:
 
     if sys.platform == "win32":
         def __js_value_to_str(self, js_value):
-            js_value_ref = _ctypes.c_void_p()
+            js_value_ref = ctypes.c_void_p()
             self.chakraCore.JsConvertValueToString(js_value, point(js_value_ref))
 
-            result = _ctypes.c_wchar_p()
-            result_len = _ctypes.c_size_t()
+            result = ctypes.c_wchar_p()
+            result_len = ctypes.c_size_t()
             self.chakraCore.JsStringToPointer(js_value_ref, point(result), point(result_len))
 
             return result.value

--- a/PyChakra/__init__.py
+++ b/PyChakra/__init__.py
@@ -64,7 +64,7 @@ class Runtime:
         self.__jsonStringify = self.eval("JSON.stringify", raw=True)[1]
 
         undefined = ctypes.c_void_p()
-        chakraCore.JsGetUndefinedValue(point(undefined))
+        self.chakraCore.JsGetUndefinedValue(point(undefined))
 
         self.__jsonStringifyArgs = (ctypes.c_void_p * 2)()
         self.__jsonStringifyArgs[0] = undefined


### PR DESCRIPTION
Hello:
It's a nice project! I have been using it for a while.
For now, all the result is in `str` type, sometimes this is not  inconvenient to us, and I hope that you can consider this PR.

There are 3 changes:
1. Return result as to corresponding python value instead of string only.
    Method used: value => json => value
2. Use some Windows-only API.
3. Add exception type info to result, not only the message string.