### PR TITLE
Fix & improve in use multi runtimes

### DIFF
--- a/PyChakra/__init__.py
+++ b/PyChakra/__init__.py
@@ -10,103 +10,230 @@
 
 
 import ctypes
-import platform
-import sys
+import re
 import json
+import threading
 from os import path
+from sys import platform
+
+
+try:
+    unicode
+except NameError:
+    unicode = str
+
+try:
+    bytes
+except NameError:
+    bytes = str
+
+preferredEncoding = None
+
+def getpreferredencoding():
+    global preferredEncoding
+
+    if preferredEncoding is None:
+        import locale
+        preferredEncoding = locale.getpreferredencoding(False)
+
+    return preferredEncoding
 
 
 def get_lib_path():
     root = path.dirname(__file__)
 
-    if sys.platform == "darwin":
+    if platform == "darwin":
         return path.join(root, "libs/osx/libChakraCore.dylib")
 
-    if sys.platform.startswith("linux"):
+    if platform.startswith("linux"):
         return path.join(root, "libs/linux/libChakraCore.so")
 
-    if sys.platform == "win32":
-        if platform.architecture()[0].startswith("64"):
+    if platform == "win32":
+        from platform import architecture
+        if architecture()[0].startswith("64"):
             return path.join(root, "libs/windows/x64/ChakraCore.dll")
         else:
             return path.join(root, "libs/windows/x86/ChakraCore.dll")
 
     raise RuntimeError("ChakraCore not support your platform: %s, detail see: https://github.com/Microsoft/ChakraCore",
-                       sys.platform)
+                       platform)
 
 
 def point(obj):
     return ctypes.byref(obj)
 
 
+is_js_variable_name = re.compile(u"""
+^
+[\$a-zA-Z_][\$\da-zA-Z_]{0,254}
+(?:\.[\$a-zA-Z_][\$\da-zA-Z_]{0,254})*
+$
+""", re.VERBOSE).match
+
+
 class Runtime:
+
+    __current_runtime = None
+    __lock = threading.RLock()
+
+    def _acquire(self):
+        if self.__lock:
+            self.__lock.acquire()
+
+        self.set_current_runtime(self)
+
+    def _release(self):
+        if self.__lock:
+            self.__lock.release()
+
+    @classmethod
+    def enable_lock(cls):
+        if isinstance(cls.__lock, threading.RLock):
+            return
+
+        cls.__lock = threading.RLock()
+
+    @classmethod
+    def disable_lock(cls):
+        if cls.__lock is None:
+            return
+
+        lock, cls.__lock = cls.__lock, None
+        try:
+            lock._release_save()
+        except:
+            pass
+
+    @classmethod
+    def set_current_runtime(cls, runtime):
+        if not isinstance(runtime, cls):
+            raise TypeError("runtime must be a Runtime object, not %s" % type(runtime).__name__)
+
+        _id = id(runtime)
+        if cls.__current_runtime != _id:
+            cls.__current_runtime = _id
+            runtime.JsSetCurrentContext(runtime.context)
 
     def __init__(self):
         # load dynamic library
-        self.chakraCore = ctypes.CDLL(get_lib_path())
+        if platform == "win32":
+            self.chakraCore = ctypes.windll[get_lib_path()]
+        else:
+            self.chakraCore = ctypes.cdll[get_lib_path()]
 
-        # create chakra runtime and context
-        self.runtime = ctypes.c_void_p()
-        self.chakraCore.JsCreateRuntime(0, 0, point(self.runtime))
-
-        self.context = ctypes.c_void_p()
-        self.chakraCore.JsCreateContext(self.runtime, point(self.context))
-
-        self.chakraCore.JsSetCurrentContext(self.context)
-
-        # call DllMain manually on non-Windows
-        if sys.platform != "win32":
+            # call DllMain manually on non-Windows
             # Attach process
             self.chakraCore.DllMain(0, 1, 0)
             # Attach main thread
             self.chakraCore.DllMain(0, 2, 0)
 
+        # create chakra runtime and context
+        self.runtime = ctypes.c_void_p()
+        self.JsCreateRuntime(0, 0, point(self.runtime))
+
+        self.context = ctypes.c_void_p()
+        self.JsCreateContext(self.runtime, point(self.context))
+
+        # get some references
+        self._acquire()
+
+        self.__global = ctypes.c_void_p()
+        undefined = ctypes.c_void_p()
+        self.JsGetGlobalObject(point(self.__global))
+        self.JsGetUndefinedValue(point(undefined))
+
+        self._release()
+
         # get JSON.stringify reference, and create its called arguments array
         self.__jsonStringify = self.eval("JSON.stringify", raw=True)[1]
-
-        undefined = ctypes.c_void_p()
-        self.chakraCore.JsGetUndefinedValue(point(undefined))
 
         self.__jsonStringifyArgs = (ctypes.c_void_p * 2)()
         self.__jsonStringifyArgs[0] = undefined
 
     def __del__(self):
-        self.chakraCore.JsDisposeRuntime(self.runtime)
+        self.JsDisposeRuntime(self.runtime)
+
+    def __getattr__(self, name):
+        return getattr(self.chakraCore, name)
 
     def eval(self, js_string, raw=False):
-        if sys.platform == "win32":
+        js_string = self.__check_js_string(js_string)
+
+        self._acquire()
+
+        if platform == "win32":
             js_source = ctypes.c_wchar_p("")
             js_script = ctypes.c_wchar_p(js_string)
 
             result = ctypes.c_void_p()
-            err = self.chakraCore.JsRunScript(js_script, 0, js_source, point(result))
+            err = self.JsRunScript(js_script, 0, js_source, point(result))
 
         else:
             js_source = ctypes.c_void_p()
-            self.chakraCore.JsCreateString("", 0, point(js_source))
+            self.JsCreateString("", 0, point(js_source))
 
             js_script = ctypes.c_void_p()
             js_string = ctypes.create_string_buffer(js_string.encode("UTF-16"))
-            self.chakraCore.JsCreateExternalArrayBuffer(js_string, len(js_string), 0, 0, point(js_script))
+            self.JsCreateExternalArrayBuffer(js_string, len(js_string), 0, 0, point(js_script))
 
             result = ctypes.c_void_p()
-            err = self.chakraCore.JsRun(js_script, 0, js_source, 0x02, point(result))
+            err = self.JsRun(js_script, 0, js_source, 0x02, point(result))
 
-        # eval success
-        if err == 0:
-            if raw:
-                return True, result
+        try:
+            # eval success
+            if err == 0:
+                if raw:
+                    return True, result
+                else:
+                    return self.__js_value_to_py_value(result)
+
+            return self.__get_error(err)
+
+        finally:
+            self._release()
+
+    def __check_js_string(self, js_string):
+        if not isinstance(js_string, unicode):
+
+            if hasattr(js_string, "tobytes"):
+                js_string = js_string.tobytes()
+
+            if isinstance(js_string, (bytes, bytearray)):
+                encoding = getpreferredencoding()
+
+                try:
+                    js_string = js_string.decode(encoding)
+                except UnicodeDecodeError:
+                    err = True
+
+                    if encoding != "UTF-8":
+                        try:
+                            js_string = js_string.decode("UTF-8")
+                        except UnicodeDecodeError:
+                            pass
+                        else:
+                            err = False
+
+                    if err:
+                        raise
+
             else:
-                return self.__js_value_to_py_value(result)
+                raise TypeError("js_string must be a string object, not %s" % type(js_string).__name__)
 
-        return self.__get_error(err)
+        return js_string
+
+    def __check_js_variable_name(self, name):
+        name = self.__check_js_string(name)
+        if is_js_variable_name(name) is None:
+            raise ValueError("variable name illegal: %r" % str(name))
+        return name
 
     def __js_value_to_py_value(self, js_value):
         self.__jsonStringifyArgs[1] = js_value
 
         # value => json
         result = ctypes.c_void_p()
-        err = self.chakraCore.JsCallFunction(self.__jsonStringify, point(self.__jsonStringifyArgs), 2, point(result))
+        err = self.JsCallFunction(self.__jsonStringify, point(self.__jsonStringifyArgs), 2, point(result))
 
         if err == 0:
             result = self.__js_value_to_str(result)
@@ -119,14 +246,56 @@ class Runtime:
 
         return self.__get_error(err)
 
-    def get_variable(self, name):
-        result = self.eval("(() => %s)()" % name)
-        if result[0]:
-            return result[1]
+    def eval_file(self, js_file):
+        js_string = open(js_file, "rb").read()
+        return self.eval(js_string)
+
+    def get_variable(self, name, raw=False):
+        name = self.__check_js_variable_name(name)
+        ok, result = self.eval(name, raw=raw)
+        if ok:
+            return result
         return None
 
     def set_variable(self, name, value):
-        return self.eval("var %s = %s" % (name, value))
+        name = self.__check_js_variable_name(name)
+
+        if isinstance(value, ctypes.c_void_p) or isinstance(value, tuple) and "c_void_p" in str(value):
+            object_name, _, property_name = name.rpartition(u".")
+
+            self._acquire()
+
+            if object_name:
+                ok, result = self.eval(object_name, raw=True)
+                if ok:
+                    result_str = self.__js_value_to_str(result)
+                    ok = result_str not in ("undefined", "null")
+                    if ok:
+                        object = result
+                    err_msg = "TypeError: %r is %s, Unable to set property %r of it" % (str(object_name), result_str, str(property_name))
+                else:
+                    err_msg = result
+                if not ok:
+                    return False, err_msg
+
+            else:
+                object = self.__global
+
+            property_name = property_name.encode("UTF-8")
+            propertyId = ctypes.c_void_p()
+            err = self.JsCreatePropertyId(property_name, len(property_name), point(propertyId))
+            if err == 0:
+                err = self.JsSetProperty(object, propertyId, value, 0)
+
+            self._release()
+
+            if err == 0:
+                return True, None
+            else:
+                return False, err_msg
+
+        else:
+            return self.eval(u"%s = %s" % (name, value))
 
     def __get_error(self, err):
         # js exception or other error
@@ -137,26 +306,26 @@ class Runtime:
 
     def __get_exception(self):
         exception = ctypes.c_void_p()
-        self.chakraCore.JsGetAndClearException(point(exception))
+        self.JsGetAndClearException(point(exception))
 
         return self.__js_value_to_str(exception)
 
     def __js_value_to_str(self, js_value):
         js_value_ref = ctypes.c_void_p()
-        self.chakraCore.JsConvertValueToString(js_value, point(js_value_ref))
+        self.JsConvertValueToString(js_value, point(js_value_ref))
 
-        if sys.platform == "win32":
+        if platform == "win32":
             result = ctypes.c_wchar_p()
             result_len = ctypes.c_size_t()
-            self.chakraCore.JsStringToPointer(js_value_ref, point(result), point(result_len))
+            self.JsStringToPointer(js_value_ref, point(result), point(result_len))
 
             return result.value
 
         else:
             str_len = ctypes.c_size_t()
-            self.chakraCore.JsCopyString(js_value_ref, 0, 0, point(str_len))
+            self.JsCopyString(js_value_ref, 0, 0, point(str_len))
 
             result = ctypes.create_string_buffer(str_len.value)
-            self.chakraCore.JsCopyString(js_value_ref, point(result), str_len.value, 0)
+            self.JsCopyString(js_value_ref, point(result), str_len.value, 0)
 
             return result.value.decode("UTF-8")

--- a/PyChakra/__init__.py
+++ b/PyChakra/__init__.py
@@ -247,19 +247,20 @@ class Runtime:
 
     def __call_js_function(self, js_function, *js_args):
         js_args_len = len(js_args)
+        call_function_args_len = js_args_len + 1
 
         if js_args_len == 1:
             # the most commonly used
             call_function_args = self.__callFunctionArgs
             call_function_args[1] = js_args[0]
         else:
-            call_function_args = (ctypes.c_void_p * (js_args_len + 1))()
+            call_function_args = (ctypes.c_void_p * call_function_args_len)()
             call_function_args[0] = self.__callFunctionArgs[0]
             for n, js_arg in enumerate(js_args):
                 call_function_args[n + 1] = js_arg
 
         result = ctypes.c_void_p()
-        err = self.JsCallFunction(js_function, point(call_function_args), 2, point(result))
+        err = self.JsCallFunction(js_function, point(call_function_args), call_function_args_len, point(result))
         call_function_args[1] = None
 
         return result, err

--- a/PyChakra/__init__.py
+++ b/PyChakra/__init__.py
@@ -312,12 +312,11 @@ class Runtime:
                 return self.__get_error(err)
 
         else:
-            if isinstance(value, unicode):
-                pass
-            elif isinstance(value, (str, bytes)):
-                value = self.__check_js_string(value)
-            else:
+            try:
                 value = json.dumps(value)
+            except TypeError as e:
+                return False, str(e)
+
             return self.eval(u"%s = %s" % (name, value))
 
     def __get_error(self, err):

--- a/PyChakra/__init__.py
+++ b/PyChakra/__init__.py
@@ -312,7 +312,13 @@ class Runtime:
                 return self.__get_error(err)
 
         else:
-            return self.eval(u"%s = %s" % (name, json.dumps(value)))
+            if isinstance(value, unicode):
+                pass
+            elif isinstance(value, (str, bytes)):
+                value = self.__check_js_string(value)
+            else:
+                value = json.dumps(value)
+            return self.eval(u"%s = %s" % (name, value))
 
     def __get_error(self, err):
         # js exception or other error

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,14 +16,14 @@ jobs:
       matrix:
         Python27:
           python.version: '2.7'
-        Python34:
-          python.version: '3.4'
         Python35:
           python.version: '3.5'
         Python36:
           python.version: '3.6'
         Python37:
           python.version: '3.7'
+        Python38:
+          python.version: '3.8'
 
     steps:
     - task: UsePythonVersion@0
@@ -45,14 +45,14 @@ jobs:
       matrix:
         Python27:
           python.version: '2.7'
-        Python34:
-          python.version: '3.4'
         Python35:
           python.version: '3.5'
         Python36:
           python.version: '3.6'
         Python37:
           python.version: '3.7'
+        Python38:
+          python.version: '3.8'
 
     steps:
     - task: UsePythonVersion@0
@@ -74,14 +74,14 @@ jobs:
       matrix:
         Python27:
           python.version: '2.7'
-        Python34:
-          python.version: '3.4'
         Python35:
           python.version: '3.5'
         Python36:
           python.version: '3.6'
         Python37:
           python.version: '3.7'
+        Python38:
+          python.version: '3.8'
 
     steps:
     - task: UsePythonVersion@0

--- a/test/chakra.test.py
+++ b/test/chakra.test.py
@@ -41,7 +41,7 @@ class TestPyChakra(unittest.TestCase):
         self.assertEqual(True, res4[0])
         self.assertEqual("function", res4[1])
 
-        res5 = chakra.set_variable("foo", "'bar'")
+        res5 = chakra.set_variable("foo", "bar")
         self.assertEqual(True, res5[0])
 
         res6 = chakra.get_variable("foo")

--- a/test/chakra.test.py
+++ b/test/chakra.test.py
@@ -45,7 +45,8 @@ class TestPyChakra(unittest.TestCase):
         self.assertEqual(True, res5[0])
 
         res6 = chakra.get_variable("foo")
-        self.assertEqual("bar", res6)
+        self.assertEqual(True, res6[0])
+        self.assertEqual("bar", res6[1])
 
         res7 = chakra.eval("(() => 2)();")
         self.assertEqual(True, res7[0])


### PR DESCRIPTION
Fixed:
1. 'JsContext' has not been set correctly when use multi runtime instances.
1. Runtime's method `set_variable` and `get_variable` do not check input arguments.

Changes:
1. Add thread lock to make invoke Runtime's method thread-safe.
1. Auto check and convert inputted string parameter to unicode type, support bytes, bytearray and memoryview.
1. Restore Runtime's method `eval_js_file` as `eval_file`, the `js_file` argument can be a path or a file-like object.
1. `Runtime.get_variable` return a tuple with `(ok/fail, value/error)`.
1. `Runtime.set_variable` argument `value` can be input in python type directly, it is no longer a Javascript literal string.
1. RAW JsRef can be returned by `Runtime.get_variable` and passed to `Runtime.set_variable`.
1. `PyChakra.lib_path` can be specified the path used to load a custom ChakraCore binary.
1. `PyChakra.preferredEncoding` can be specified which coding used to auto convert string.

Notice:
1. `Runtime.get_variable` returned result's type was changed, see above.
1. `Runtime.get_variable` input argument's type was changed, see above.
1. Threading RLock is disabled by default, if want to use it, creat runtime like this:
```py
ctx = Runtime(threading=True)
```